### PR TITLE
erlang:now() is deprecated. Use erlang:timestamp() instead.

### DIFF
--- a/examples/tasks/src/repeating.erl
+++ b/examples/tasks/src/repeating.erl
@@ -28,5 +28,5 @@ handle_msg(reset, _From, _N) ->
     {reply, ok, 1}.
 
 timestamp() ->
-    {M, S, U} = erlang:now(),
+    {M, S, U} = erlang:timestamp(),
     M * 1000000 + S + U / 1000000.

--- a/src/e2_task.erl
+++ b/src/e2_task.erl
@@ -242,5 +242,5 @@ set_start(#state{start=undefined}=State) ->
 set_start(State) -> State.
 
 timestamp() ->
-    {M, S, U} = erlang:now(),
+    {M, S, U} = erlang:timestamp(),
     M * 1000000000 + S * 1000 + U div 1000.

--- a/src/e2_task_impl.erl
+++ b/src/e2_task_impl.erl
@@ -38,5 +38,5 @@ delay(#repeat{interval=Interval, start=Start}) ->
     ((Now - Start) div Interval + 1) * Interval + Start - Now.
 
 timestamp() ->
-    {M, S, U} = erlang:now(),
+    {M, S, U} = erlang:timestamp(),
     M * 1000000000 + S * 1000 + U div 1000.


### PR DESCRIPTION
See http://www.erlang.org/doc/man/erlang.html#now-0 and
http://www.erlang.org/doc/apps/erts/time_correction.html for more
information.

Attention: These changes are part of erlang as of OTP 18 (ERTS version 7.0).